### PR TITLE
dianostic_header_icon -> diagnostic_header_icon

### DIFF
--- a/configs/nvim/lua/malo/lspsaga-nvim.lua
+++ b/configs/nvim/lua/malo/lspsaga-nvim.lua
@@ -12,7 +12,7 @@ require'lspsaga'.init_lsp_saga {
   warn_sign = s.warning,
   infor_sign = s.info,
   hint_sign = s.question,
-  dianostic_header_icon = '  ',
+  diagnostic_header_icon = '  ',
   code_action_icon = ' ',
   code_action_prompt = {
     enable = true,


### PR DESCRIPTION
> dianostic_header_icon will be deprecated soon due to misspelling. use 'diagnostic_header_icon'